### PR TITLE
Add Drag and Drop feature to invoicex-gui

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.0
+current_version = 0.1.1
 tag = True
 commit = True
 message = Bump version: {current_version} -> {new_version} [ci skip]

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ The application is built using `PyQt5 <https://www.riverbankcomputing.com/softwa
 v0.1.0
 
 - Linux: `Linux Package <https://github.com/invoice-x/invoicex-gui/releases/download/v0.1.0/invoicex-gui-v0.1.0-linux.tar.gz>`_
-- Windows: `Windows executable <https://github.com/invoice-x/invoicex-gui/releases/download/v0.1.0/invoicex-gui-v0.1.0-windows.zip>`_
+- Windows (64-bit): `Windows executable <https://github.com/invoice-x/invoicex-gui/releases/download/v0.1.0/invoicex-gui-v0.1.0-windows.zip>`_
 - MacOS: `MacOS executable <https://github.com/invoice-x/invoicex-gui/releases/download/v0.1.0/invoicex-gui-v0.1.0-macos.zip>`_
 
 

--- a/invoicex/invoicex.py
+++ b/invoicex/invoicex.py
@@ -542,15 +542,20 @@ class InvoiceX(QMainWindow):
             QMainWindow.resizeEvent(self, event)
 
     def dragEnterEvent(self, event):
-        if event.mimeData().hasFormat('text/plain') and event.mimeData().text().startswith('file://') and event.mimeData().text().endswith('.pdf'):
+        if event.mimeData().hasFormat('text/plain'):
             event.accept()
         else:
             event.ignore()
     
     def dropEvent(self, event):
         fileURL = event.mimeData().text()
-        self.fileName = (fileURL[7: ], "pdf (*.pdf)")
-        self.load_pdf_file()
+        if fileURL.startswith('file://') and fileURL.endswith('.pdf'):
+            self.fileName = (fileURL[7: ], "pdf (*.pdf)")
+            self.load_pdf_file()
+        else:
+            QMessageBox.critical(self, 'Invalid File Type',
+                                 'Only PDF files are supported as input',
+                                 QMessageBox.Ok)
 
     def eventFilter(self, source, event):
         if event.type() == QEvent.Close and source is self.fields:

--- a/invoicex/invoicex.py
+++ b/invoicex/invoicex.py
@@ -36,6 +36,7 @@ class InvoiceX(QMainWindow):
 
         self.fileLoaded = False
         self.dialog = None
+        self.setAcceptDrops(True)
         self.initUI()
 
     def initUI(self):
@@ -539,6 +540,17 @@ class InvoiceX(QMainWindow):
                 Qt.KeepAspectRatio, Qt.SmoothTransformation))
             self.square.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Ignored)
             QMainWindow.resizeEvent(self, event)
+
+    def dragEnterEvent(self, event):
+        if event.mimeData().hasFormat('text/plain') and event.mimeData().text().startswith('file://') and event.mimeData().text().endswith('.pdf'):
+            event.accept()
+        else:
+            event.ignore()
+    
+    def dropEvent(self, event):
+        fileURL = event.mimeData().text()
+        self.fileName = (fileURL[7: ], "pdf (*.pdf)")
+        self.load_pdf_file()
 
     def eventFilter(self, source, event):
         if event.type() == QEvent.Close and source is self.fields:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from os import path
 
 setup(
     name='invoicex-gui',
-    version='0.1.0',
+    version='0.1.1',
     author='Harshit Joshi',
     author_email='harshit.joshi@outlook.com',
     url='https://github.com/invoice-x/invoicex-gui',


### PR DESCRIPTION
The file opening feels tedious at times so added drag and drop functionality to the application.

### Tests:
* [x] Ubuntu 18.10
* [x] KDE Neon 15.10.1 [Ubuntu 18.04 base]
* [ ] Windows - I don't have immediate access to a Windows device and hence wasn't able to test the behavior on windows. 


Also the tests were done with the invoice in the repository and another random pdf to check for the dialog box pop-up.
Also added a critical message in case something other than a pdf file is dropped onto the application.  